### PR TITLE
Don't treat non-200 status codes as exceptions

### DIFF
--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.hlth.hnclientv2;
 
 import java.io.File;
+import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.time.LocalDate;
 
@@ -98,11 +99,12 @@ public class Route extends RouteBuilder {
      *   5. Sends the message to an http endpoint (HNS-ESB) with the JWT attached
      *   6. Returns the response to the original tcp caller
      */
-    @Override
+    @SuppressWarnings("unchecked")
+	@Override
     public void configure() throws Exception {
         init();
 
-        onException(HttpHostConnectException.class).process(new FailureProcessor())
+        onException(HttpHostConnectException.class, UnknownHostException.class).process(new FailureProcessor())
         .log("Recieved body ${body}").handled(true);
         
         onException(IllegalArgumentException.class).process(new FailureProcessor())

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
@@ -8,7 +8,6 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.http.conn.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,9 +104,6 @@ public class Route extends RouteBuilder {
 
         onException(HttpHostConnectException.class).process(new FailureProcessor())
         .log("Recieved body ${body}").handled(true);
-
-        onException(HttpOperationFailedException.class).process(new FailureProcessor())
-        .log("Recieved body ${body}").handled(true);
         
         onException(IllegalArgumentException.class).process(new FailureProcessor())
         .log("Recieved body ${body}").handled(true);
@@ -122,7 +118,7 @@ public class Route extends RouteBuilder {
             .setBody().method(new ProcessV2ToJson()).id("ProcessV2ToJson")
             .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
             .log("Sending to HNSecure")
-            .to("{{http-protocol}}://{{hnsecure-hostname}}:{{hnsecure-port}}/{{hnsecure-endpoint}}?throwExceptionOnFailure=true").id("ToHnSecure")
+            .to("{{http-protocol}}://{{hnsecure-hostname}}:{{hnsecure-port}}/{{hnsecure-endpoint}}?throwExceptionOnFailure=false").id("ToHnSecure")
             .log("Received response from HNSecure")
             .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
             .setBody().method(new FhirPayloadExtractor()).id("FhirPayloadExtractor")

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/ErrorBuilder.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/ErrorBuilder.java
@@ -28,17 +28,25 @@ public class ErrorBuilder {
 
 
 	/**
+	 * @param errMsg
+	 * @return
+	 */
+	public static String buildErrorMessage(String errMsg) {
+		return buildErrorMessage(null, errMsg);
+	}
+	
+	/**
 	 * @param v2Msg
 	 * @param errMsg
 	 * @return
 	 */
-	public static String buildErrorMessage(String v2Msg,String errMsg) {
-		return buildMSH(v2Msg) +buildMSA(v2Msg,errMsg);
+	public static String buildErrorMessage(String v2Msg, String errMsg) {
+		return buildMSH(v2Msg) + buildMSA(v2Msg, errMsg);
 	}
 
 	private static String buildMSA(String v2Msg, String errMsg) {
-		if(StringUtils.isBlank(v2Msg)) {
-			v2Msg= HL7ERROR_DEFAULT;
+		if (StringUtils.isBlank(v2Msg)) {
+			v2Msg = HL7ERROR_DEFAULT;
 		}
 		
 		StringBuilder sb = new StringBuilder();

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessor.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessor.java
@@ -2,10 +2,11 @@ package ca.bc.gov.hlth.hnclientv2.error;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.http.conn.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.hlth.hncommon.util.LoggingUtil;
 
 public class FailureProcessor implements Processor {
 
@@ -13,7 +14,7 @@ public class FailureProcessor implements Processor {
 
 	@Override
 	public void process(Exchange exchange) {
-		logger.debug("process: Failure Processor is called");
+		logger.debug("{} - Failure Processor is called", LoggingUtil.getMethodName());
 		
 		Exception exception = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
 		String errMsg = MessageUtil.UNKNOWN_EXCEPTION;
@@ -22,10 +23,6 @@ public class FailureProcessor implements Processor {
 			errMsg = MessageUtil.INVALID_PARAMETER;
 		} else if (exception instanceof HttpHostConnectException) {
 			errMsg = MessageUtil.SERVER_NO_CONNECTION;
-		} else if (exception instanceof HttpOperationFailedException) {
-			HttpOperationFailedException hofe = (HttpOperationFailedException)exception;
-			// TODO (weskubo-cgi) It may be necessary to just send a generic code to the POS
-			errMsg = hofe.getStatusText();
 		} else if (exception instanceof NoInputHL7Exception) {
 			errMsg = MessageUtil.HL7_ERROR_MSG_NO_INPUT_HL7;
 		} else if (exception instanceof ServerNoConnectionException) {
@@ -35,7 +32,7 @@ public class FailureProcessor implements Processor {
 			errMsg = MessageUtil.UNKNOWN_EXCEPTION;
 		}
 		
-		logger.error("Processing Exception of type {} with message {}", exception.getClass().getName(), errMsg);
+		logger.error("{} - Processing Exception of type {} with message {}", LoggingUtil.getMethodName(), getClass().getName(), errMsg);
 		
 		// Give the default error
 		String defaultErrorMessage = ErrorBuilder.buildErrorMessage("", errMsg);

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessor.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessor.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.hlth.hnclientv2.error;
 
+import java.net.UnknownHostException;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.http.conn.HttpHostConnectException;
@@ -22,6 +24,8 @@ public class FailureProcessor implements Processor {
 		if (exception instanceof IllegalArgumentException) {
 			errMsg = MessageUtil.INVALID_PARAMETER;
 		} else if (exception instanceof HttpHostConnectException) {
+			errMsg = MessageUtil.SERVER_NO_CONNECTION;
+		} else if (exception instanceof UnknownHostException) {			
 			errMsg = MessageUtil.SERVER_NO_CONNECTION;
 		} else if (exception instanceof NoInputHL7Exception) {
 			errMsg = MessageUtil.HL7_ERROR_MSG_NO_INPUT_HL7;

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessor.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessor.java
@@ -39,7 +39,7 @@ public class FailureProcessor implements Processor {
 		logger.error("{} - Processing Exception of type {} with message {}", LoggingUtil.getMethodName(), getClass().getName(), errMsg);
 		
 		// Give the default error
-		String defaultErrorMessage = ErrorBuilder.buildErrorMessage("", errMsg);
+		String defaultErrorMessage = ErrorBuilder.buildErrorMessage(errMsg);
 		exchange.getIn().setBody(defaultErrorMessage);
 	}
 }

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractor.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractor.java
@@ -27,7 +27,7 @@ public class FhirPayloadExtractor {
     	// and return an error response
     	if (StringUtils.isBlank(fhirMessage)) {
     		logger.error("{} - Response from HNS ESB has empty body", LoggingUtil.getMethodName());
-    		return ErrorBuilder.buildErrorMessage("", MessageUtil.SERVER_NO_CONNECTION);
+    		return ErrorBuilder.buildErrorMessage(MessageUtil.SERVER_NO_CONNECTION);
     	}
 
         JSONObject fhirMessageJSON;
@@ -39,7 +39,7 @@ public class FhirPayloadExtractor {
 	    	// and return an error response.
 			// E.g. a 404 error will likely return HTML
 			logger.error("{} - Response from HNS ESB has invalid body: {}", LoggingUtil.getMethodName(), e.getMessage());
-    		return ErrorBuilder.buildErrorMessage("", MessageUtil.SERVER_NO_CONNECTION);
+    		return ErrorBuilder.buildErrorMessage(MessageUtil.SERVER_NO_CONNECTION);
 		}
         
         FHIRJsonMessage encodedExtractedMessage = FHIRJsonUtil.parseJson2FHIRMsg(fhirMessageJSON); // get the data property

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractor.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractor.java
@@ -1,30 +1,46 @@
 package ca.bc.gov.hlth.hnclientv2.handler;
 
-import java.io.UnsupportedEncodingException;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
 import ca.bc.gov.hlth.hnclientv2.error.CamelCustomException;
+import ca.bc.gov.hlth.hnclientv2.error.ErrorBuilder;
+import ca.bc.gov.hlth.hnclientv2.error.MessageUtil;
 import ca.bc.gov.hlth.hncommon.json.fhir.FHIRJsonMessage;
 import ca.bc.gov.hlth.hncommon.json.fhir.FHIRJsonUtil;
 import ca.bc.gov.hlth.hncommon.util.LoggingUtil;
 import ca.bc.gov.hlth.hncommon.util.StringUtil;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
-import net.minidev.json.parser.ParseException;
 
 public class FhirPayloadExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(FhirPayloadExtractor.class);
 
     @Handler
-    public static String extractFhirPayload(Exchange exchange,String fhirMessage) throws ParseException, UnsupportedEncodingException, CamelCustomException {
+    public static String extractFhirPayload(Exchange exchange, String fhirMessage) throws CamelCustomException {
+    	// Assume that an empty response body means there is an issue with the server
+    	// and return an error response
+    	if (StringUtils.isBlank(fhirMessage)) {
+    		logger.error("{} - Response from HNS ESB has empty body", LoggingUtil.getMethodName());
+    		return ErrorBuilder.buildErrorMessage("", MessageUtil.SERVER_NO_CONNECTION);
+    	}
 
-    	JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
-        JSONObject fhirMessageJSON = (JSONObject) jsonParser.parse(fhirMessage);
+        JSONObject fhirMessageJSON;
+		try {
+	    	JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+			fhirMessageJSON = (JSONObject) jsonParser.parse(fhirMessage);
+		} catch (Exception e) {
+			// Assume that a parsing exception means there is an issue with the server 
+	    	// and return an error response.
+			// E.g. a 404 error will likely return HTML
+			logger.error("{} - Response from HNS ESB has invalid body: {}", LoggingUtil.getMethodName(), e.getMessage());
+    		return ErrorBuilder.buildErrorMessage("", MessageUtil.SERVER_NO_CONNECTION);
+		}
         
         FHIRJsonMessage encodedExtractedMessage = FHIRJsonUtil.parseJson2FHIRMsg(fhirMessageJSON); // get the data property
 
@@ -34,11 +50,12 @@ public class FhirPayloadExtractor {
         try {
         	extractedMessage = StringUtil.decodeBase64(encodedExtractedMessage.getV2MessageData());
         } catch (IllegalArgumentException e) {
-        	logger.error("Exception while decoding message ", e);
+        	logger.error("{} - Exception while decoding message: {}", LoggingUtil.getMethodName(), e.getMessage());
         	throw new CamelCustomException(e.getMessage());
         }
 		logger.debug("{}: The decoded HL7 message is: {}", LoggingUtil.getMethodName(), extractedMessage);
         
         return extractedMessage;
     }    
+	
 }

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handshakeserver/ConnectionHandler.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handshakeserver/ConnectionHandler.java
@@ -88,7 +88,7 @@ public class ConnectionHandler implements Callable<Void> {
 				performTransaction(socketInput, socketOutput);
 			} else {
 				logger.warn("{} - Handshake failed: {} {}", LoggingUtil.getMethodName(), ret_code, System.lineSeparator());
-				hnSecureResponse = ErrorBuilder.buildErrorMessage("",ret_code);
+				hnSecureResponse = ErrorBuilder.buildErrorMessage(ret_code);
 				sendResponse(socketOutput, hnSecureResponse);
 				// reset decodeseed
 				decodeSeed = 0;
@@ -101,7 +101,7 @@ public class ConnectionHandler implements Callable<Void> {
 			if (ret_code.contentEquals(MessageUtil.HNET_RTRN_SUCCESS)) {
 				ret_code = MessageUtil.HNET_RTRN_INVALIDFORMATERROR;
 			}
-			hnSecureResponse = ErrorBuilder.buildErrorMessage("", ret_code);
+			hnSecureResponse = ErrorBuilder.buildErrorMessage(ret_code);
 			try {
 				sendResponse(socketOutput, hnSecureResponse);
 			} catch (IOException ioe) {
@@ -220,7 +220,7 @@ public class ConnectionHandler implements Callable<Void> {
 				logger.debug("{} Error receiving DT segment from Listener: {}", methodName, ret_code);
 				ret_code = MessageUtil.HNET_RTRN_INVALIDFORMATERROR;
 				hnSecureResponse = ErrorBuilder
-						.buildErrorMessage("", MessageUtil.HL7_ERROR_MSG_ERROR_DT_HEADER_TO_HNCLIENT);
+						.buildErrorMessage(MessageUtil.HL7_ERROR_MSG_ERROR_DT_HEADER_TO_HNCLIENT);
 			}
 
 		}

--- a/hnclient-v2/src/test/java/ca/bc/gov/hlth/hnclientv2/error/ErrorBuilderUnitTest.java
+++ b/hnclient-v2/src/test/java/ca/bc/gov/hlth/hnclientv2/error/ErrorBuilderUnitTest.java
@@ -8,11 +8,10 @@ class ErrorBuilderUnitTest {
 	private static String v2Msg= "MSH|~\\&|HNWEB|moh_hnclient_dev|RAIGT-PRSN-DMGR|BC00001013|20170125122125|train96|R03|9826|D|2.4||\r\n"
 			+ "ZHD|20170125122125|^^00000010|HNAIADMINISTRATION||||2.4\n" + "PID||1234567890^^^BC^PH";
 	
-
 	@Test
 	void test_buildErrorMessage_whenV2MsgAndErrMsgIsNull() {
 		
-		String errMsg =ErrorBuilder.buildErrorMessage(null, null);
+		String errMsg = ErrorBuilder.buildErrorMessage(null);
 		String dataSegments[] = errMsg.split("\n");
 		String expectedMSH ="MSH|^~\\\\&|HNCLIENT|UNKNOWNFACILITY|HNCLIENT|UNKNOWNCLIENT";
 		String expectedMSA = "MSA|AR|||||";	
@@ -23,7 +22,7 @@ class ErrorBuilderUnitTest {
 	@Test
 	void test_buildErrorMessage_whenV2MsgIsNull() {
 		
-		String errMsg =ErrorBuilder.buildErrorMessage(null, "HNET_RTRN_INVALIDFORMATERROR");
+		String errMsg = ErrorBuilder.buildErrorMessage("HNET_RTRN_INVALIDFORMATERROR");
 		String dataSegments[] = errMsg.split("\n");
 		String expectedMSH ="MSH|^~\\\\&|HNCLIENT|UNKNOWNFACILITY|HNCLIENT|UNKNOWNCLIENT";
 		String expectedMSA = "MSA|AR||HNET_RTRN_INVALIDFORMATERROR|||";	
@@ -33,7 +32,7 @@ class ErrorBuilderUnitTest {
 	
 	@Test
 	void test_buildErrorMessage() {
-		String errMsg =ErrorBuilder.buildErrorMessage(v2Msg, "HNET_RTRN_INVALIDFORMATERROR");
+		String errMsg = ErrorBuilder.buildErrorMessage(v2Msg, "HNET_RTRN_INVALIDFORMATERROR");
 		String dataSegments[] = errMsg.split("\n");
 		String expectedMSH ="MSH|~\\&|HNCLIENT|BC00001013|HNCLIENT|moh_hnclient_dev";
 		String expectedMSHMSg ="train96|ACK|R03|9826|D|2.4";

--- a/hnclient-v2/src/test/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessorTest.java
+++ b/hnclient-v2/src/test/java/ca/bc/gov/hlth/hnclientv2/error/FailureProcessorTest.java
@@ -11,7 +11,6 @@ import org.apache.camel.Predicate;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.http.conn.HttpHostConnectException;
 import org.junit.jupiter.api.Test;
@@ -32,9 +31,6 @@ public class FailureProcessorTest extends CamelTestSupport {
 			@Override
 			public void configure() throws Exception {
 		        onException(HttpHostConnectException.class).process(new FailureProcessor())
-		        .log("Recieved body ${body}").handled(true);
-
-		        onException(HttpOperationFailedException.class).process(new FailureProcessor())
 		        .log("Recieved body ${body}").handled(true);
 		        
 		        onException(IllegalArgumentException.class).process(new FailureProcessor())
@@ -137,31 +133,6 @@ public class FailureProcessorTest extends CamelTestSupport {
 				throw new IllegalArgumentException();
 			}
 			
-		});
-	}
-	
-	@Test
-	public void testProcess_HttpOperationFailedException_400() throws Exception {
-		String expectedErrorMsg = "Bad Request";
-		Integer header = 400;
-		assertErrorMessage(v2Msg, expectedErrorMsg, header);
-	}
-	
-	@Test
-	public void testProcess_HttpOperationFailedException_500() throws Exception {
-		String expectedErrorMsg = "Internal Server Error";
-		Integer header = 500;
-		assertErrorMessage(v2Msg, expectedErrorMsg, header);
-	}
-	
-	private void assertErrorMessage(String v2Message, String expectedErrorMsg, Integer statusCode) throws Exception {
-		assertErrorMessage(v2Message, expectedErrorMsg, new Processor() {
-			
-			@Override
-			public void process(Exchange exchange) throws Exception {
-				throw new HttpOperationFailedException("", statusCode, expectedErrorMsg, "", null, "");
-				
-			}
 		});
 	}
 	


### PR DESCRIPTION
Since we now expect HNS ESB to return a proper fhir+json body (including applicable HL7v2 message) for all error codes, we don't want to be throwing HttpOperationFailedExceptions. We just want to follow the normal flow of message processing. Exceptions generated within HNS Client are still handled the same.