### PR TITLE
updated route logging to use existing config and be human readable

### DIFF
--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
@@ -117,15 +117,17 @@ public class Route extends RouteBuilder {
         .log("Received body ${body}").handled(true);
         
         from("direct:start").routeId("hnclient-route")
+            .streamCaching()
             .setHeader("Authorization").method(retrieveAccessToken).id("RetrieveAccessToken")
             .setBody().method(new Base64Encoder()).id("Base64Encoder")
             .setBody().method(new ProcessV2ToJson()).id("ProcessV2ToJson")
             .log(LoggingLevel.INFO, logger,
                     "Route - TransactionId: ${header.X-Request-Id} Message created successfully, " +
-                            "sending to {{http-protocol}}://{{hnsecure-hostname}}{{hnsecure-endpoint}}")
-            .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
+                            "sending to {{http-protocol}}://{{hnsecure-hostname}}/{{hnsecure-endpoint}}")
+            .log(LoggingLevel.DEBUG, logger, "Route - TransactionId: ${header.X-Request-Id} Sending Message with Auth Header: ${header.Authorization}")
+            .log(LoggingLevel.DEBUG, logger, "Route - TransactionId: ${header.X-Request-Id} Sending Message with Message Body: ${body}")
             .to("{{http-protocol}}://{{hnsecure-hostname}}:{{hnsecure-port}}/{{hnsecure-endpoint}}?throwExceptionOnFailure=false").id("ToHnSecure")
-            .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
+            .log(LoggingLevel.DEBUG, logger, "Route - TransactionId: ${header.X-Request-Id} Received Response with Message Body: ${body}")
             .setBody().method(new FhirPayloadExtractor()).id("FhirPayloadExtractor")
             .convertBodyTo(String.class);
     }


### PR DESCRIPTION
Adjusted route logging to use the camel log eip https://camel.apache.org/components/3.12.x/eips/log-eip.html
instead of the logger component https://camel.apache.org/components/3.12.x/log-component.html

Enabled stream caching, otherwise the log option will "consume" the message body. 
https://camel.apache.org/manual/stream-caching.html
Stream caching just stores the message in memory during the route (up to 128KB, our messages are only 1KB)

Also fixed a missing / in an existing log statement