### PR TITLE
update new lines so bathl7 is compatible with rtrans-esb

### DIFF
--- a/moh-hni-bathl7/src/main/java/com/cgi/bathl7/BatHL7Processor.java
+++ b/moh-hni-bathl7/src/main/java/com/cgi/bathl7/BatHL7Processor.java
@@ -142,7 +142,7 @@ public class BatHL7Processor {
 				if (sb == null) {
 					sb = new StringBuilder();
 				}
-				sb.append(nextLine).append("\n");
+				sb.append(nextLine).append("\r\n");
 			}
 
 		} catch (IOException fe) {


### PR DESCRIPTION
RTrans requires newlines to be \r\n 