### PR TITLE
11412 toggle whitespace trimming

### DIFF
--- a/hnclient-installer/application.properties
+++ b/hnclient-installer/application.properties
@@ -53,3 +53,10 @@ cer-file = C:\\Dev\\Downloads\\moh_hnclient_dev.cer
 cert-upload-endpoint = https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms/v2_pos/clients/769006a4-b981-4e33-8ef4-a1b0591d0375/certificates/jwt.credential/upload-certificate
 ### Specify MOH_HNCLIENT_KEYSTORE_PASSWORD as an operating system environment variable
 days-before-expiry-to-renew=30
+
+#Property to indicate if the Message should be returned untrimmed from HNS Client. Trimming the message is the default behaviour and removes additional characters from 
+#the beginning and end of the message string. This includes carriage returns after the message content. As removing these caused an issue for some connected applications this property
+#was added to allow these connected partners preserve the message while at the same time not affecting connected partners that had already installed and tested HNS Client. 
+#Defaults to 'false' (standard for most connected applictions) and the property can be ignored unless the missing carriage returns causes an issue for your connected application. If so, set 
+#it to true and all message characters including trailing carriage returns will be returned.
+preserve-message=false

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/Route.java
@@ -101,6 +101,9 @@ public class Route extends RouteBuilder {
 
     private RetrieveAccessToken retrieveAccessToken;
 
+    @PropertyInject(defaultValue = "false", value = "preserve-message")
+    private boolean preserveMessage;
+    
     /**
      * Camel route that:
      *   1. Receives a message over tcp using the HandShakeServer to implement a specific handshake protocol
@@ -136,7 +139,7 @@ public class Route extends RouteBuilder {
             .log(LoggingLevel.DEBUG, logger, "Route - TransactionId: ${header.X-Request-Id} Sending Message with Message Body: ${body}")
             .to("{{http-protocol}}://{{hnsecure-hostname}}:{{hnsecure-port}}/{{hnsecure-endpoint}}?throwExceptionOnFailure=false").id("ToHnSecure")
             .log(LoggingLevel.DEBUG, logger, "Route - TransactionId: ${header.X-Request-Id} Received Response with Message Body: ${body}")
-            .setBody().method(new FhirPayloadExtractor()).id("FhirPayloadExtractor")
+            .setBody().method(new FhirPayloadExtractor(preserveMessage)).id("FhirPayloadExtractor")
             .convertBodyTo(String.class);
     }
 

--- a/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractor.java
+++ b/hnclient-v2/src/main/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractor.java
@@ -20,8 +20,17 @@ public class FhirPayloadExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(FhirPayloadExtractor.class);
 
+    private boolean preserveMessage;
+    
+	public FhirPayloadExtractor() {
+	}
+
+	public FhirPayloadExtractor(boolean preserveMessage) {
+		this.preserveMessage = preserveMessage;
+	}
+
     @Handler
-    public static String extractFhirPayload(Exchange exchange, String fhirMessage) throws CamelCustomException {
+    public String extractFhirPayload(Exchange exchange, String fhirMessage) throws CamelCustomException {
     	// Assume that an empty response body means there is an issue with the server
     	// and return an error response
     	if (StringUtils.isBlank(fhirMessage)) {
@@ -46,14 +55,25 @@ public class FhirPayloadExtractor {
         // Only way to verify if message is base64 encoded is to decode and check for no exception
         // In case string is not Base 64, decoder throws IllegalArgumentException. Handled that exception.
         String extractedMessage;
+        
         try {
-        	extractedMessage =  StringUtils.trim(StringUtil.decodeBase64(encodedExtractedMessage.getV2MessageData()));
+        	/* Some connected partners applications that consume the response message required that any carriage return
+        	 * in the message be kept. For these cases the message is not trimmed as this removes additional characters including 
+        	 * carriage returns. The standard behaviour is to trim the message.
+        	 *   
+        	 */
+        	if (preserveMessage) {
+        		extractedMessage =  StringUtil.decodeBase64(encodedExtractedMessage.getV2MessageData());
+        	} else {
+        		extractedMessage =  StringUtils.trim(StringUtil.decodeBase64(encodedExtractedMessage.getV2MessageData()));
+        	}
         } catch (IllegalArgumentException e) {
         	logger.error("{} - Exception while decoding message: {}", LoggingUtil.getMethodName(), e.getMessage());
         	throw new CamelCustomException(e.getMessage());
         }
-		logger.debug("{}: The decoded HL7 message is: {}", LoggingUtil.getMethodName(), extractedMessage);
-        
+		logger.debug("{}: The decoded HL7 message is:\n{}", LoggingUtil.getMethodName(), extractedMessage);
+		logger.debug("{}: End Message.", LoggingUtil.getMethodName());
+		
         return extractedMessage;
     }    
 	

--- a/hnclient-v2/src/main/resources/application.properties
+++ b/hnclient-v2/src/main/resources/application.properties
@@ -14,32 +14,22 @@ accept-remote-connections=true
 valid-ip-list-file=fwlist.txt
 
 ## to hnsecure
-# For HNSecure:
+# For HNSecure local:
 #http-protocol=http
 #hnsecure-hostname = localhost
 #hnsecure-port = 14885
 #hnsecure-endpoint = hl7v2
 
-# For HNSecure direct to fireblade:
-#hnsecure-hostname = fireblade.hlth.gov.bc.ca
-#hnsecure-port = 14885
-#hnsecure-endpoint = hl7v2
-
 # For HNSecure direct to Openshift:
-#hnsecure-hostname = hnsesb-test.apps.silver.devops.gov.bc.ca
-#hnsecure-port = 80
-#hnsecure-endpoint = hl7v2
-
-#For gateway
-http-protocol=https
-# For HNSecure via Kong Gateway:
-hnsecure-hostname = hnsesb-dev-api-gov-bc-ca.test.api.gov.bc.ca
-hnsecure-port = 443
+http-protocol=http
+hnsecure-hostname = hnsesb-argo-dev.apps.silver.devops.gov.bc.ca
+hnsecure-port = 80
 hnsecure-endpoint = hl7v2
 
-
- #For HNSecure via Proxy server:
-#hnsecure-hostname = hniesb-dev.hlth.gov.bc.ca
+#For gateway
+#http-protocol=https
+# For HNSecure via Kong Gateway:
+#hnsecure-hostname = hnsesb-dev-api-gov-bc-ca.test.api.gov.bc.ca
 #hnsecure-port = 443
 #hnsecure-endpoint = hl7v2
 
@@ -77,3 +67,10 @@ cer-file = C:\\Dev\\Downloads\\moh_hnclient_dev.cer
 cert-upload-endpoint = https://common-logon-dev.hlth.gov.bc.ca/auth/admin/realms/v2_pos/clients/769006a4-b981-4e33-8ef4-a1b0591d0375/certificates/jwt.credential/upload-certificate
 ### Specify MOH_HNCLIENT_KEYSTORE_PASSWORD as an operating system environment variable
 days-before-expiry-to-renew=30
+
+#Property to indicate if the Message should be returned untrimmed from HNS Client. Trimming the message is the default behaviour and removes additional characters from 
+#the beginning and end of the message string. This includes carriage returns after the message content. As removing these caused an issue for some connected applications this property
+#was added to allow these connected partners preserve the message while at the same time not affecting connected partners that had already installed and tested HNS Client. 
+#Defaults to 'false' (standard for most connected applictions) and the property can be ignored unless the missing carriage returns causes an issue for your connected application. If so, set 
+#it to true and all message characters including trailing carriage returns will be returned.
+preserve-message=false

--- a/hnclient-v2/src/test/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractorTest.java
+++ b/hnclient-v2/src/test/java/ca/bc/gov/hlth/hnclientv2/handler/FhirPayloadExtractorTest.java
@@ -23,7 +23,7 @@ public class FhirPayloadExtractorTest extends CamelTestSupport {
 			@Override
 			public void configure() {
 				from("direct:sampleInput")
-				.setBody().method(new FhirPayloadExtractor())
+				.setBody().method(new FhirPayloadExtractor(false))
                 .to("mock:output");
 			}
 		};


### PR DESCRIPTION
This change adds an application property to indicate if the v2 message should be returned untrimmed from HNS Client. Trimming the message is the default behaviour and removes additional characters from the beginning and end of the message string. This includes carriage returns after the message content. As removing these caused an issue for some connected applications this property was added to allow these connected partners preserve the message while at the same time not affecting connected partners that had already installed and tested HNS Client. 

Also cleaned up the sample application properties for some unused endpoints.